### PR TITLE
fix Windows App name case

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "babylonreactnativesample",
+  "name": "BabylonReactNativeSample",
   "displayName": "BabylonReactNativeSample"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babylonreactnativesample",
+  "name": "BabylonReactNativeSample",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/windows/babylonreactnativesample/App.cpp
+++ b/windows/babylonreactnativesample/App.cpp
@@ -11,7 +11,7 @@ using namespace xaml::Controls;
 using namespace xaml::Navigation;
 
 using namespace Windows::ApplicationModel;
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
 /// <summary>
 /// Initializes the singleton application object.  This is the first line of
@@ -90,4 +90,4 @@ void App::OnNavigationFailed(IInspectable const&, NavigationFailedEventArgs cons
     throw hresult_error(E_FAIL, hstring(L"Failed to load Page ") + e.SourcePageType().Name);
 }
 
-} // namespace winrt::babylonreactnativesample::implementation
+} // namespace winrt::BabylonReactNativeSample::implementation

--- a/windows/babylonreactnativesample/App.h
+++ b/windows/babylonreactnativesample/App.h
@@ -10,7 +10,7 @@ namespace activation = winrt::Microsoft::UI::Xaml;
 namespace activation = winrt::Windows::ApplicationModel::Activation;
 #endif
 
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
     struct App : AppT<App>
     {
@@ -22,4 +22,4 @@ namespace winrt::babylonreactnativesample::implementation
       private:
         using super = AppT<App>;
     };
-} // namespace winrt::babylonreactnativesample::implementation
+} // namespace winrt::BabylonReactNativeSample::implementation

--- a/windows/babylonreactnativesample/App.idl
+++ b/windows/babylonreactnativesample/App.idl
@@ -1,3 +1,3 @@
-namespace babylonreactnativesample
+namespace BabylonReactNativeSample
 {
 }

--- a/windows/babylonreactnativesample/App.xaml
+++ b/windows/babylonreactnativesample/App.xaml
@@ -1,8 +1,8 @@
 ﻿<react:ReactApplication
-    x:Class="babylonreactnativesample.App"
+    x:Class="BabylonReactNativeSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:babylonreactnativesample"
+    xmlns:local="using:BabylonReactNativeSample"
     xmlns:react="using:Microsoft.ReactNative">
     <Application.Resources>
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />

--- a/windows/babylonreactnativesample/MainPage.cpp
+++ b/windows/babylonreactnativesample/MainPage.cpp
@@ -9,7 +9,7 @@
 using namespace winrt;
 using namespace xaml;
 
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
     MainPage::MainPage()
     {

--- a/windows/babylonreactnativesample/MainPage.h
+++ b/windows/babylonreactnativesample/MainPage.h
@@ -2,7 +2,7 @@
 #include "MainPage.g.h"
 #include <winrt/Microsoft.ReactNative.h>
 
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
     struct MainPage : MainPageT<MainPage>
     {
@@ -10,7 +10,7 @@ namespace winrt::babylonreactnativesample::implementation
     };
 }
 
-namespace winrt::babylonreactnativesample::factory_implementation
+namespace winrt::BabylonReactNativeSample::factory_implementation
 {
     struct MainPage : MainPageT<MainPage, implementation::MainPage>
     {

--- a/windows/babylonreactnativesample/MainPage.idl
+++ b/windows/babylonreactnativesample/MainPage.idl
@@ -1,6 +1,6 @@
 #include "NamespaceRedirect.h"
 
-namespace babylonreactnativesample
+namespace BabylonReactNativeSample
 {
     [default_interface]
     runtimeclass MainPage : XAML_NAMESPACE.Controls.Page

--- a/windows/babylonreactnativesample/MainPage.xaml
+++ b/windows/babylonreactnativesample/MainPage.xaml
@@ -1,8 +1,8 @@
 <Page
-    x:Class="babylonreactnativesample.MainPage"
+    x:Class="BabylonReactNativeSample.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:babylonreactnativesample"
+    xmlns:local="using:BabylonReactNativeSample"
     xmlns:react="using:Microsoft.ReactNative"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,7 +10,7 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <react:ReactRootView 
         x:Name="ReactRootView"
-        ComponentName="babylonreactnativesample"
+        ComponentName="BabylonReactNativeSample"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         MinHeight="400"/>
 </Page>

--- a/windows/babylonreactnativesample/Package.appxmanifest
+++ b/windows/babylonreactnativesample/Package.appxmanifest
@@ -31,12 +31,12 @@
     <Application
       Id="App"
       Executable="$targetnametoken$.exe"
-      EntryPoint="babylonreactnativesample.App">
+      EntryPoint="BabylonReactNativeSample.App">
       <uap:VisualElements
-        DisplayName="babylonreactnativesample"
+        DisplayName="BabylonReactNativeSample"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="babylonreactnativesample"
+        Description="BabylonReactNativeSample"
         BackgroundColor="transparent">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />

--- a/windows/babylonreactnativesample/ReactPackageProvider.cpp
+++ b/windows/babylonreactnativesample/ReactPackageProvider.cpp
@@ -4,7 +4,7 @@
 
 using namespace winrt::Microsoft::ReactNative;
 
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
@@ -12,4 +12,4 @@ void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuil
     AddAttributedModules(packageBuilder);
 }
 
-} // namespace winrt::babylonreactnativesample::implementation
+} // namespace winrt::BabylonReactNativeSample::implementation

--- a/windows/babylonreactnativesample/ReactPackageProvider.h
+++ b/windows/babylonreactnativesample/ReactPackageProvider.h
@@ -2,12 +2,12 @@
 
 #include "winrt/Microsoft.ReactNative.h"
 
-namespace winrt::babylonreactnativesample::implementation
+namespace winrt::BabylonReactNativeSample::implementation
 {
     struct ReactPackageProvider : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider>
     {
     public: // IReactPackageProvider
         void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
     };
-} // namespace winrt::babylonreactnativesample::implementation
+} // namespace winrt::BabylonReactNativeSample::implementation
 

--- a/windows/babylonreactnativesample/babylonreactnativesample.vcxproj
+++ b/windows/babylonreactnativesample/babylonreactnativesample.vcxproj
@@ -7,14 +7,14 @@
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{ddcc7f38-4de1-422e-978f-99f12f3d11a0}</ProjectGuid>
-    <ProjectName>babylonreactnativesample</ProjectName>
-    <RootNamespace>babylonreactnativesample</RootNamespace>
+    <ProjectName>BabylonReactNativeSample</ProjectName>
+    <RootNamespace>BabylonReactNativeSample</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
     <PackageCertificateKeyFile>babylonreactnativesample_TemporaryKey.pfx</PackageCertificateKeyFile>
     <PackageCertificateThumbprint>FF15239FC348362A490F29D8C8BF9C759433DC73</PackageCertificateThumbprint>
@@ -64,7 +64,8 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings"></ImportGroup>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>


### PR DESCRIPTION
My yesterday's is breaking iOS. Changing app name case instead for Windows.